### PR TITLE
Add docs and examples

### DIFF
--- a/docs/core_docs/docs/integrations/llms/azure.mdx
+++ b/docs/core_docs/docs/integrations/llms/azure.mdx
@@ -43,6 +43,22 @@ const model = new AzureOpenAI({
 });
 ```
 
+If you're using Azure Managed Identity, you can also pass the credentials directly to the constructor:
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { AzureOpenAI } from "@langchain/azure-openai";
+
+const credentials = new DefaultAzureCredential();
+
+const model = new AzureOpenAI({
+  credentials,
+  azureOpenAIEndpoint: "<your_endpoint>",
+  azureOpenAIApiDeploymentName: "<your_deployment_name",
+  modelName: "<your_model>",
+});
+```
+
 ### LLM usage example
 
 import CodeBlock from "@theme/CodeBlock";

--- a/docs/core_docs/docs/integrations/llms/azure.mdx
+++ b/docs/core_docs/docs/integrations/llms/azure.mdx
@@ -1,9 +1,67 @@
 # Azure OpenAI
 
+[Azure OpenAI](https://azure.microsoft.com/products/ai-services/openai-service/) is a cloud service to help you quickly develop generative AI experiences with a diverse set of prebuilt and curated models from OpenAI, Meta and beyond.
+
+LangChain.js supports integration with [Azure OpenAI](https://azure.microsoft.com/products/ai-services/openai-service/) using either the dedicated [Azure OpenAI SDK](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/openai/openai) or the [OpenAI SDK](https://github.com/openai/openai-node).
+
+You can learn more about Azure OpenAI and its difference with the OpenAI API on [this page](https://learn.microsoft.com/azure/ai-services/openai/overview). If you don't have an Azure account, you can [create a free account](https://azure.microsoft.com/free/) to get started.
+
+## Using Azure OpenAI SDK
+
+You'll first need to install the [`@langchain/azure-openai`](https://www.npmjs.com/package/@langchain/azure-openai) package:
+
+import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
+
+<IntegrationInstallTooltip></IntegrationInstallTooltip>
+
+```bash npm2yarn
+npm install -S @langchain/azure-openai
+```
+
+You'll also need to have an Azure OpenAI instance deployed. You can deploy a version on Azure Portal following [this guide](https://learn.microsoft.com/azure/ai-services/openai/how-to/create-resource?pivots=web-portal).
+
+Once you have your instance running, make sure you have the endpoint and key. You can find them in the Azure Portal, under the "Keys and Endpoint" section of your instance.
+
+You can then define the following environment variables to use the service:
+
+```bash
+AZURE_OPENAI_API_ENDPOINT=<YOUR_ENDPOINT>
+AZURE_OPENAI_API_KEY=<YOUR_KEY>
+AZURE_OPENAI_API_DEPLOYMENT_NAME=<YOUR_DEPLOYMENT_NAME>
+```
+
+Alternatively, you can pass the values directly to the `AzureSDKOpenAI` constructor:
+
+```typescript
+import { AzureSDKOpenAI } from "@langchain/azure-openai";
+
+const model = new AzureSDKOpenAI({
+  azureOpenAIEndpoint: "<your_endpoint>",
+  azureOpenAIApiKey: "<your_key>",
+  azureOpenAIApiDeploymentName: "<your_deployment_name",
+  modelName: "<your_model>",
+});
+```
+
+### LLM usage example
+
+import CodeBlock from "@theme/CodeBlock";
+import LLMExample from "@examples/llms/azure_openai.ts";
+
+<CodeBlock language="text">{LLMExample}</CodeBlock>
+
+### Chat usage example
+
+import CodeBlock from "@theme/CodeBlock";
+import ChatExample from "@examples/llms/azure_openai-chat.ts";
+
+<CodeBlock language="text">{ChatExample}</CodeBlock>
+
+## Using OpenAI SDK
+
 You can also use the `OpenAI` class to call OpenAI models hosted on Azure.
 
-For example, if your Azure instance is hosted under `https://{MY_INSTANCE_NAME}.openai.azure.com/openai/deployments/{DEPLOYMENT_NAME}`, you
-could initialize your instance like this:
+For example, if your Azure instance is hosted under `https://{MY_INSTANCE_NAME}.openai.azure.com/openai/deployments/{DEPLOYMENT_NAME}`, you could initialize your instance like this:
 
 import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
 
@@ -23,7 +81,7 @@ const model = new OpenAI({
   azureOpenAIApiInstanceName: "{MY_INSTANCE_NAME}",
   azureOpenAIApiDeploymentName: "{DEPLOYMENT_NAME}",
 });
-const res = await model.call(
+const res = await model.invoke(
   "What would be a good company name a company that makes colorful socks?"
 );
 console.log({ res });
@@ -43,7 +101,7 @@ const model = new OpenAI({
   azureOpenAIBasePath:
     "https://westeurope.api.microsoft.com/openai/deployments", // In Node.js defaults to process.env.AZURE_OPENAI_BASE_PATH
 });
-const res = await model.call(
+const res = await model.invoke(
   "What would be a good company name a company that makes colorful socks?"
 );
 console.log({ res });

--- a/docs/core_docs/docs/integrations/llms/azure.mdx
+++ b/docs/core_docs/docs/integrations/llms/azure.mdx
@@ -30,12 +30,12 @@ AZURE_OPENAI_API_KEY=<YOUR_KEY>
 AZURE_OPENAI_API_DEPLOYMENT_NAME=<YOUR_DEPLOYMENT_NAME>
 ```
 
-Alternatively, you can pass the values directly to the `AzureSDKOpenAI` constructor:
+Alternatively, you can pass the values directly to the `AzureOpenAI` constructor:
 
 ```typescript
-import { AzureSDKOpenAI } from "@langchain/azure-openai";
+import { AzureOpenAI } from "@langchain/azure-openai";
 
-const model = new AzureSDKOpenAI({
+const model = new AzureOpenAI({
   azureOpenAIEndpoint: "<your_endpoint>",
   azureOpenAIApiKey: "<your_key>",
   azureOpenAIApiDeploymentName: "<your_deployment_name",
@@ -82,7 +82,7 @@ const model = new OpenAI({
   azureOpenAIApiDeploymentName: "{DEPLOYMENT_NAME}",
 });
 const res = await model.invoke(
-  "What would be a good company name a company that makes colorful socks?"
+  "What would be a good company name for a company that makes colorful socks?"
 );
 console.log({ res });
 ```
@@ -102,7 +102,7 @@ const model = new OpenAI({
     "https://westeurope.api.microsoft.com/openai/deployments", // In Node.js defaults to process.env.AZURE_OPENAI_BASE_PATH
 });
 const res = await model.invoke(
-  "What would be a good company name a company that makes colorful socks?"
+  "What would be a good company name for a company that makes colorful socks?"
 );
 console.log({ res });
 ```

--- a/docs/core_docs/docs/integrations/llms/index.mdx
+++ b/docs/core_docs/docs/integrations/llms/index.mdx
@@ -33,8 +33,6 @@ Each LLM integration can optionally provide native implementations for invoke, s
 | Ollama                |   ✅   |   ✅   |  ✅   |
 | OpenAI                |   ✅   |   ✅   |  ✅   |
 | OpenAIChat            |   ✅   |   ✅   |  ✅   |
-| PromptLayerAzureOpenAI     |   ✅   |   ✅   |  ✅   |
-| PromptLayerAzureOpenAIChat |   ✅   |   ✅   |  ✅   |
 | PromptLayerOpenAI     |   ✅   |   ✅   |  ✅   |
 | PromptLayerOpenAIChat |   ✅   |   ✅   |  ✅   |
 | Portkey               |   ✅   |   ✅   |  ✅   |

--- a/docs/core_docs/docs/integrations/llms/index.mdx
+++ b/docs/core_docs/docs/integrations/llms/index.mdx
@@ -22,6 +22,8 @@ Each LLM integration can optionally provide native implementations for invoke, s
 | :-------------------- | :----: | :----: | :---: |
 | AI21                  |   ✅   |   ❌   |  ✅   |
 | AlephAlpha            |   ✅   |   ❌   |  ✅   |
+| AzureOpenAI           |   ✅   |   ✅   |  ✅   |
+| AzureChatOpenAI       |   ✅   |   ✅   |  ✅   |
 | CloudflareWorkersAI   |   ✅   |   ✅   |  ✅   |
 | Cohere                |   ✅   |   ❌   |  ✅   |
 | Fireworks             |   ✅   |   ✅   |  ✅   |
@@ -29,10 +31,10 @@ Each LLM integration can optionally provide native implementations for invoke, s
 | HuggingFaceInference  |   ✅   |   ❌   |  ✅   |
 | LlamaCpp              |   ✅   |   ✅   |  ✅   |
 | Ollama                |   ✅   |   ✅   |  ✅   |
-| OpenAIChat            |   ✅   |   ✅   |  ✅   |
-| PromptLayerOpenAIChat |   ✅   |   ✅   |  ✅   |
 | OpenAI                |   ✅   |   ✅   |  ✅   |
 | OpenAIChat            |   ✅   |   ✅   |  ✅   |
+| PromptLayerAzureOpenAI     |   ✅   |   ✅   |  ✅   |
+| PromptLayerAzureOpenAIChat |   ✅   |   ✅   |  ✅   |
 | PromptLayerOpenAI     |   ✅   |   ✅   |  ✅   |
 | PromptLayerOpenAIChat |   ✅   |   ✅   |  ✅   |
 | Portkey               |   ✅   |   ✅   |  ✅   |

--- a/docs/core_docs/docs/integrations/text_embedding/azure_openai.mdx
+++ b/docs/core_docs/docs/integrations/text_embedding/azure_openai.mdx
@@ -4,6 +4,74 @@ keywords: [AzureOpenAIEmbeddings]
 
 # Azure OpenAI
 
+[Azure OpenAI](https://azure.microsoft.com/products/ai-services/openai-service/) is a cloud service to help you quickly develop generative AI experiences with a diverse set of prebuilt and curated models from OpenAI, Meta and beyond.
+
+LangChain.js supports integration with [Azure OpenAI](https://azure.microsoft.com/products/ai-services/openai-service/) using either the dedicated [Azure OpenAI SDK](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/openai/openai) or the [OpenAI SDK](https://github.com/openai/openai-node).
+
+You can learn more about Azure OpenAI and its difference with the OpenAI API on [this page](https://learn.microsoft.com/azure/ai-services/openai/overview). If you don't have an Azure account, you can [create a free account](https://azure.microsoft.com/free/) to get started.
+
+## Using Azure OpenAI SDK
+
+You'll first need to install the [`@langchain/azure-openai`](https://www.npmjs.com/package/@langchain/azure-openai) package:
+
+import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
+
+<IntegrationInstallTooltip></IntegrationInstallTooltip>
+
+```bash npm2yarn
+npm install -S @langchain/azure-openai
+```
+
+You'll also need to have an Azure OpenAI instance deployed. You can deploy a version on Azure Portal following [this guide](https://learn.microsoft.com/azure/ai-services/openai/how-to/create-resource?pivots=web-portal).
+
+Once you have your instance running, make sure you have the endpoint and key. You can find them in the Azure Portal, under the "Keys and Endpoint" section of your instance.
+
+You can then define the following environment variables to use the service:
+
+```bash
+AZURE_OPENAI_API_ENDPOINT=<YOUR_ENDPOINT>
+AZURE_OPENAI_API_KEY=<YOUR_KEY>
+AZURE_OPENAI_API_EMBEDDING_DEPLOYMENT_NAME=<YOUR_EMBEDDING_DEPLOYMENT_NAME>
+```
+
+Alternatively, you can pass the values directly to the `AzureOpenAI` constructor:
+
+```typescript
+import { AzureOpenAI } from "@langchain/azure-openai";
+
+const model = new AzureOpenAI({
+  azureOpenAIEndpoint: "<your_endpoint>",
+  azureOpenAIApiKey: "<your_key>",
+  azureOpenAIApiDeploymentName: "<your_embedding_deployment_name",
+  modelName: "<your_model>",
+});
+```
+
+If you're using Azure Managed Identity, you can also pass the credentials directly to the constructor:
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { AzureOpenAI } from "@langchain/azure-openai";
+
+const credentials = new DefaultAzureCredential();
+
+const model = new AzureOpenAI({
+  credentials,
+  azureOpenAIEndpoint: "<your_endpoint>",
+  azureOpenAIApiDeploymentName: "<your_embedding_deployment_name",
+  modelName: "<your_model>",
+});
+```
+
+### Usage example
+
+import CodeBlock from "@theme/CodeBlock";
+import Example from "@examples/llms/azure_openai.ts";
+
+<CodeBlock language="text">{Example}</CodeBlock>
+
+## Using OpenAI SDK
+
 The `OpenAIEmbeddings` class can also use the OpenAI API on Azure to generate embeddings for a given text. By default it strips new line characters from the text, as recommended by OpenAI, but you can disable this by passing `stripNewLines: false` to the constructor.
 
 For example, if your Azure instance is hosted under `https://{MY_INSTANCE_NAME}.openai.azure.com/openai/deployments/{DEPLOYMENT_NAME}`, you

--- a/examples/src/embeddings/azure_openai.ts
+++ b/examples/src/embeddings/azure_openai.ts
@@ -1,0 +1,9 @@
+import { AzureOpenAIEmbeddings } from "@langchain/azure-openai";
+
+export const run = async () => {
+  const model = new AzureOpenAIEmbeddings();
+  const res = await model.embedQuery(
+    "What would be a good company name for a company that makes colorful socks?"
+  );
+  console.log({ res });
+};

--- a/examples/src/llms/azure_openai-chat.ts
+++ b/examples/src/llms/azure_openai-chat.ts
@@ -1,0 +1,17 @@
+import { AzureSDKChatOpenAI } from "@langchain/azure-openai";
+
+export const run = async () => {
+  const model = new AzureSDKChatOpenAI({
+    prefixMessages: [
+      {
+        role: "system",
+        content: "You are a helpful assistant that answers in pirate language",
+      },
+    ],
+    maxTokens: 50,
+  });
+  const res = await model.invoke(
+    "What would be a good company name a company that makes colorful socks?"
+  );
+  console.log({ res });
+};

--- a/examples/src/llms/azure_openai-chat.ts
+++ b/examples/src/llms/azure_openai-chat.ts
@@ -2,6 +2,7 @@ import { AzureChatOpenAI } from "@langchain/azure-openai";
 
 export const run = async () => {
   const model = new AzureChatOpenAI({
+    modelName: "gpt-4",
     prefixMessages: [
       {
         role: "system",

--- a/examples/src/llms/azure_openai-chat.ts
+++ b/examples/src/llms/azure_openai-chat.ts
@@ -1,7 +1,7 @@
-import { AzureSDKChatOpenAI } from "@langchain/azure-openai";
+import { AzureChatOpenAI } from "@langchain/azure-openai";
 
 export const run = async () => {
-  const model = new AzureSDKChatOpenAI({
+  const model = new AzureChatOpenAI({
     prefixMessages: [
       {
         role: "system",
@@ -11,7 +11,7 @@ export const run = async () => {
     maxTokens: 50,
   });
   const res = await model.invoke(
-    "What would be a good company name a company that makes colorful socks?"
+    "What would be a good company name for a company that makes colorful socks?"
   );
   console.log({ res });
 };

--- a/examples/src/llms/azure_openai.ts
+++ b/examples/src/llms/azure_openai.ts
@@ -1,14 +1,14 @@
-import { AzureSDKOpenAI } from "@langchain/azure-openai";
+import { AzureOpenAI } from "@langchain/azure-openai";
 
 export const run = async () => {
-  const model = new AzureSDKOpenAI({
+  const model = new AzureOpenAI({
     modelName: "gpt-4",
     temperature: 0.7,
     maxTokens: 1000,
     maxRetries: 5,
   });
   const res = await model.invoke(
-    "Question: What would be a good company name a company that makes colorful socks?\nAnswer:"
+    "Question: What would be a good company name for a company that makes colorful socks?\nAnswer:"
   );
   console.log({ res });
 };

--- a/examples/src/llms/azure_openai.ts
+++ b/examples/src/llms/azure_openai.ts
@@ -1,0 +1,14 @@
+import { AzureSDKOpenAI } from "@langchain/azure-openai";
+
+export const run = async () => {
+  const model = new AzureSDKOpenAI({
+    modelName: "gpt-4",
+    temperature: 0.7,
+    maxTokens: 1000,
+    maxRetries: 5,
+  });
+  const res = await model.invoke(
+    "Question: What would be a good company name a company that makes colorful socks?\nAnswer:"
+  );
+  console.log({ res });
+};

--- a/libs/langchain-azure-openai/README.md
+++ b/libs/langchain-azure-openai/README.md
@@ -2,6 +2,8 @@
 
 This package contains the Azure SDK for OpenAI LangChain.js integrations.
 
+It provides Azure OpenAI support through the [Azure SDK for OpenAI](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/openai/openai) library. 
+
 ## Installation
 
 ```bash npm2yarn
@@ -38,22 +40,28 @@ The field you need depends on the package manager you're using, but we recommend
 
 ## Chat Models
 
-This package contains the `ChatOpenAI` class, which is the recommended way to interface with the OpenAI series of models.
+This package contains the `AzureChatOpenAI` class, which is the recommended way to interface with the OpenAI series of models.
 
 To use, install the requirements, and configure your environment.
 
 ```bash
-export OPENAI_API_KEY=your-api-key
+export AZURE_OPENAI_API_ENDPOINT=<your_endpoint>
+export AZURE_OPENAI_API_KEY=<your_key>
+export AZURE_OPENAI_API_DEPLOYMENT_NAME=<your_deployment_name>
 ```
 
-Then initialize
+Then initialize the model and make the calls:
 
 ```typescript
-import { ChatOpenAI } from "@langchain/openai";
+import { AzureChatOpenAI } from "@langchain/azure-openai";
 
-const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+const model = new AzureChatOpenAI({
   modelName: "gpt-4-1106-preview",
+  // Note that the following are optional, and will default to the values below
+  // if not provided.
+  azureOpenAIEndpoint: process.env.AZURE_OPENAI_API_ENDPOINT,
+  azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
+  azureOpenAIApiDeploymentName: process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
 });
 const response = await model.invoke(new HumanMessage("Hello world!"));
 ```
@@ -61,11 +69,15 @@ const response = await model.invoke(new HumanMessage("Hello world!"));
 ### Streaming
 
 ```typescript
-import { ChatOpenAI } from "@langchain/openai";
+import { AzureChatOpenAI } from "@langchain/azure-openai";
 
-const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+const model = new AzureChatOpenAI({
   modelName: "gpt-4-1106-preview",
+  // Note that the following are optional, and will default to the values below
+  // if not provided.
+  azureOpenAIEndpoint: process.env.AZURE_OPENAI_API_ENDPOINT,
+  azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
+  azureOpenAIApiDeploymentName: process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
 });
 const response = await model.stream(new HumanMessage("Hello world!"));
 ```
@@ -75,43 +87,21 @@ const response = await model.stream(new HumanMessage("Hello world!"));
 This package also adds support for OpenAI's embeddings model.
 
 ```typescript
-import { OpenAIEmbeddings } from "@langchain/openai";
+import { AzureOpenAIEmbeddings } from "@langchain/azure-openai";
 
-const embeddings = new OpenAIEmbeddings({
-  apiKey: process.env.OPENAI_API_KEY,
+const embeddings = new AzureOpenAIEmbeddings({
+  // Note that the following are optional, and will default to the values below
+  // if not provided.
+  azureOpenAIEndpoint: process.env.AZURE_OPENAI_API_ENDPOINT,
+  azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
+  azureOpenAIApiDeploymentName: process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
 });
 const res = await embeddings.embedQuery("Hello world");
 ```
 
-## Azure SDK for OpenAI
-
-This package also supports OpenAI through [Azure SDK for OpenAI](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/openai/openai) library. 
-
-To use, install the requirements, and configure your environment.
-
-```bash
-export AZURE_OPENAI_API_ENDPOINT=your-api-endpoint
-export AZURE_OPENAI_API_DEPLOYMENT_NAME=your-deployment
-export AZURE_OPENAI_API_KEY=your-api-key
-export AZURE_OPENAI_API_INSTANCE_NAME=your-api-instance-name
-export AZURE_OPENAI_API_VERSION=your-api-version
-```
-
-Then, you could initialize the `AzureSDKOpenAI` and make the calls
-
-```typescript
-import { AzureSDKOpenAI } from "@langchain/openai";
-
-const model = new AzureSDKOpenAI({
-  maxTokens: 5,
-  modelName: "gpt-3.5-turbo-instruct",
-});
-const res = await model.call("Print hello world");
-```
-
 ## Development
 
-To develop the OpenAI package, you'll need to follow these instructions:
+To develop the Azure OpenAI package, you'll need to follow these instructions:
 
 ### Install dependencies
 
@@ -128,7 +118,7 @@ yarn build
 Or from the repo root:
 
 ```bash
-yarn build --filter=@langchain/openai
+yarn build --filter=@langchain/azure-openai
 ```
 
 ### Run tests

--- a/libs/langchain-azure-openai/README.md
+++ b/libs/langchain-azure-openai/README.md
@@ -1,11 +1,11 @@
-# @langchain/openai
+# @langchain/azure-openai
 
-This package contains the LangChain.js integrations for OpenAI through their SDK.
+This package contains the Azure SDK for OpenAI LangChain.js integrations.
 
 ## Installation
 
 ```bash npm2yarn
-npm install @langchain/openai
+npm install @langchain/azure-openai
 ```
 
 This package, along with the main LangChain package, depends on [`@langchain/core`](https://npmjs.com/package/@langchain/core/).


### PR DESCRIPTION
I added docs for the new SDK integration and code examples (also included in the docs).

The docs are aligned with the other Azure services integration with:
- A short service description with an azure.microsoft.com link
- A link to the Learn docs explaining the differences between Azure OpenAI and OpenAI
- A link to create a free Azure account
- A link to the Learn docs for deployment instructions
- Code usage examples

I anticipated the change to use the package name `@langchain/azure-openai` directly, so the examples currently won't work until the refactoring is made.

Let me know if you have any comments regarding the docs or examples.
